### PR TITLE
update README for SPM on Xcode13

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ To integrate `AlertToast` into your Xcode project using Xcode 12, specify it in 
 https://github.com/elai950/AlertToast.git, :branch="master"
 ```
 
+For Xcode 13, please refer [this article](https://iiroalhonen.medium.com/adding-a-swift-package-dependency-in-xcode-13-937b2caaf218) to install `AlertToast` 
+
 ------
 
 ### Manually


### PR DESCRIPTION
The old `File > Swift Packages > Add Package Dependency...` is no longer there in Xcode 13. 

This pull request added the instruction for using swift package manager on Xcode 13.