### PR TITLE
Fix memory leak when `alert` closure captures any state of view

### DIFF
--- a/Sources/AlertToast/AlertToast.swift
+++ b/Sources/AlertToast/AlertToast.swift
@@ -456,6 +456,7 @@ public struct AlertToastModifier: ViewModifier{
                             withAnimation(Animation.spring()){
                                 self.workItem?.cancel()
                                 isPresenting = false
+                                self.workItem = nil
                             }
                         }
                     }
@@ -485,6 +486,7 @@ public struct AlertToastModifier: ViewModifier{
                             withAnimation(Animation.spring()){
                                 self.workItem?.cancel()
                                 isPresenting = false
+                                self.workItem = nil
                             }
                         }
                     }
@@ -500,6 +502,7 @@ public struct AlertToastModifier: ViewModifier{
                             withAnimation(Animation.spring()){
                                 self.workItem?.cancel()
                                 isPresenting = false
+                                self.workItem = nil
                             }
                         }
                     }
@@ -585,6 +588,7 @@ public struct AlertToastModifier: ViewModifier{
             let task = DispatchWorkItem {
                 withAnimation(Animation.spring()){
                     isPresenting = false
+                    workItem = nil
                 }
             }
             workItem = task


### PR DESCRIPTION
## Description

If `alert` closure captures any `@State` of a view, `workItem` retains that and the view could not be released.
Clearing `workItem` should resolve this issue.

## Environments

Xcode: Version 13.3 (13E113)
iOS Deployment Target: 14.0

## Sample code

<details>

```swift
import SwiftUI
import AlertToast

@main
struct SampleApp: App {
    var body: some Scene {
        WindowGroup {
            LeakSampleView()
        }
    }
}

final class SampleViewModel: ObservableObject {
    init() {
        print("====== init ======")
    }
    deinit {
        print("====== deinit ======")
    }
}

struct LeakSampleView: View {
    @State private var isPresented = false
    var body: some View {
        Button {
            isPresented = true
        } label: {
            Text("Show LeakSampleChildView").padding()
        }.fullScreenCover(isPresented: $isPresented) {
            LeakSampleChildView()
        }
    }
}

struct LeakSampleChildView: View {
    @Environment(\.presentationMode) var presentationMode
    @State private var toastActive = false
    @State private var message = "FOOBAR"
    @StateObject private var viewModel = SampleViewModel()

    var body: some View {
        VStack {
            Button {
                toastActive = true
            } label: {
                Text("Show Toast!!").padding()
            }
            .toast(isPresenting: $toastActive) {
                AlertToast(displayMode: .alert, type: .regular, title: message) // 🔴 captures @State (in this case: message)
//                AlertToast(displayMode: .alert, type: .regular, title: "FOOBAR") // ✅ this code does not cause this issue
            }
            Button {
                presentationMode.wrappedValue.dismiss()
            } label: {
                Text("Dismiss").padding()
            }
        }
    }
}

struct LeakSampleView_Previews: PreviewProvider {
    static var previews: some View {
        LeakSampleView()
    }
}
```

</details>

### How to reproduce

1. Run sample code
2. tap "Show LeakSampleChildView" (`SampleViewModel.init()` is called)
3. tap "Show Toast!!"
4. tap "Dismiss" (`SampleViewModel.deinit()` should be called but not)
