### PR TITLE
AlertToast hangs on iOS 13. Alert text is clipped

### DIFF
--- a/Sources/AlertToast/AlertToast.swift
+++ b/Sources/AlertToast/AlertToast.swift
@@ -381,7 +381,6 @@ public struct AlertToast: View{
                 }
             }
         }
-        .fixedSize(horizontal: true, vertical: false)
         .padding()
         .withFrame(type != .regular && type != .loading)
         .alertBackground(style?.backgroundColor ?? nil)
@@ -577,6 +576,10 @@ public struct AlertToastModifier: ViewModifier{
     }
     
     private func onAppearAction(){
+        guard workItem == nil else {
+            return
+        }
+        
         if alert().type == .loading{
             duration = 0
             tapToDismiss = false


### PR DESCRIPTION
Hello! 

First of all thank you for the great lib, we find it really helpful.

We stumbled upon an issue on iOS 13 where the app would hang when we tried to display an alert. Here's the code we used:
```
.toast(isPresenting: $viewModel.showToast) {
    AlertToast(type: .complete(Color.tangemGreen), title: "contract_address_copied_message".localized)
}
```

Whenever we set `showToast` to `true` it would freeze and the CPU would go to 100%. Our investigation showed that the library was repeatedly calling `onAppearAction` from `onReceive`.

Upon fixing that problem we encountered a different one — the text in the `.alert` mode was not wrapped by SwiftUI. Removing `.fixedSize` fixed the issue and did not seem to introduce any side effects.

Attaching the screenshot of the clipping.

Thanks again,

Andy

<img width="444" alt="Screenshot 2022-04-14 at 17 04 25" src="https://user-images.githubusercontent.com/12209839/163402324-6d7381cc-e40e-4674-b2c7-a7ce88e5700d.png">

