### PR TITLE
Fix bug on macOS: HUD toasts are not visible on screen

### DIFF
--- a/Sources/AlertToast/AlertToast.swift
+++ b/Sources/AlertToast/AlertToast.swift
@@ -436,11 +436,7 @@ public struct AlertToastModifier: ViewModifier{
     }
     
     private var offset: CGFloat{
-#if os(iOS)
         return -hostRect.midY + alertRect.height
-#else
-        return (-hostRect.midY + screen.midY) + alertRect.height
-#endif
     }
     
     @ViewBuilder


### PR DESCRIPTION
Currently, the offset is being calculated incorrectly, causing .hud toasts to not be visible on macOS. This commit fixes this issue.