### PR TITLE
Fix: alert modifier should not modify duration to zero when alert type equals to alert

### DIFF
--- a/Sources/AlertToast/AlertToast.swift
+++ b/Sources/AlertToast/AlertToast.swift
@@ -575,10 +575,9 @@ public struct AlertToastModifier: ViewModifier{
         guard workItem == nil else {
             return
         }
-        
-        if alert().type == .loading{
-            duration = 0
+        guard alert().type != .loading else {
             tapToDismiss = false
+            return
         }
         
         if duration > 0{


### PR DESCRIPTION
Signed-off-by: zangqilong <zangqilong@gmail.com>

It's better to not set duration to zero when type equal to loading.
here is the sample code to explain.
I create a  AlertContext to manage different alert state and use single `.toast` modifier to present different toast.
```
enum AlertState: Equatable {
    case none
    case success(title: String)
    case failure(title: String)
    case loading
    
    var duration: TimeInterval {
        return 2
    }
    
    func alertView() -> AlertToast {
        switch self {
        case .none:
            return AlertToast(displayMode: .alert, type: .regular)
        case .success(let title):
            return AlertToast(displayMode: .alert, type: .complete(.white), title: title)
        case let .failure(title):
            return AlertToast(displayMode: .alert, type: .error(.white), title: title)
        case .loading:
            return AlertToast(displayMode: .alert, type: .loading)
        }
    }
}

final class AlertContext: ObservableObject {
    @Published var showAlert = false
    @Published var state = AlertState.none {
        didSet {
            switch state {
            case .none:
                showAlert = false
            default:
                showAlert = true
            }
        }
    }
}

```

and  the view use this
`
        }
        .toast(isPresenting: $context.showAlert, duration: context.state.duration) {
            context.state.alertView()
        }
`

if use the old way to set the duration = 0 when alertType == .alert, the modifier's duration will be zero forever
it means when  I change the context.state to success or failure, the auto dimiss will never work again.