### PR TITLE
Add ActivityIndicator's color support

### DIFF
--- a/Sources/AlertToast/ActivityIndicator.swift
+++ b/Sources/AlertToast/ActivityIndicator.swift
@@ -11,6 +11,12 @@ import SwiftUI
 @available(macOS 11, *)
 struct ActivityIndicator: NSViewRepresentable {
     
+	let color: Color
+	
+	init(color: Color) {
+	    self.color = color
+	}
+	
     func makeNSView(context: NSViewRepresentableContext<ActivityIndicator>) -> NSProgressIndicator {
         let nsView = NSProgressIndicator()
         
@@ -28,9 +34,25 @@ struct ActivityIndicator: NSViewRepresentable {
 @available(iOS 13, *)
 struct ActivityIndicator: UIViewRepresentable {
 
+    let color: Color
+    
+    init(color: Color) {
+        self.color = color
+    }
+	
     func makeUIView(context: UIViewRepresentableContext<ActivityIndicator>) -> UIActivityIndicatorView {
         
         let progressView = UIActivityIndicatorView(style: .large)
+		if #available(iOS 14.0, *) {
+		    if let cgColor = color.cgColor?.copy() {
+		        progressView.color = UIColor(cgColor: cgColor)
+		    }
+		} else {
+		    let uiHostingController = UIHostingController(rootView: color)
+		    if let cgColor = uiHostingController.view.backgroundColor?.cgColor.copy() {
+		        progressView.color = UIColor(cgColor: cgColor)
+		    }
+		}
         progressView.startAnimating()
         
         return progressView

--- a/Sources/AlertToast/AlertToast.swift
+++ b/Sources/AlertToast/AlertToast.swift
@@ -137,12 +137,13 @@ public struct AlertToast: View{
                    titleColor: Color? = nil,
                    subTitleColor: Color? = nil,
                    titleFont: Font? = nil,
-                   subTitleFont: Font? = nil)
+                   subTitleFont: Font? = nil,
+                   indicatorColor: Color? = nil)
         
         ///Get background color
         var backgroundColor: Color? {
             switch self{
-            case .style(backgroundColor: let color, _, _, _, _):
+            case .style(backgroundColor: let color, _, _, _, _, _):
                 return color
             }
         }
@@ -150,7 +151,7 @@ public struct AlertToast: View{
         /// Get title color
         var titleColor: Color? {
             switch self{
-            case .style(_,let color, _,_,_):
+            case .style(_,let color, _,_,_,_):
                 return color
             }
         }
@@ -158,7 +159,7 @@ public struct AlertToast: View{
         /// Get subTitle color
         var subtitleColor: Color? {
             switch self{
-            case .style(_,_, let color, _,_):
+            case .style(_,_, let color, _,_,_):
                 return color
             }
         }
@@ -166,7 +167,7 @@ public struct AlertToast: View{
         /// Get title font
         var titleFont: Font? {
             switch self {
-            case .style(_, _, _, titleFont: let font, _):
+            case .style(_, _, _, titleFont: let font, _,_):
                 return font
             }
         }
@@ -174,8 +175,16 @@ public struct AlertToast: View{
         /// Get subTitle font
         var subTitleFont: Font? {
             switch self {
-            case .style(_, _, _, _, subTitleFont: let font):
+            case .style(_, _, _, _, subTitleFont: let font,_):
                 return font
+            }
+        }
+        
+        /// Get indicator color
+        var indicatorColor: Color? {
+            switch self {
+            case .style(_, _, _, _, _, indicatorColor: let color):
+                return color
             }
         }
     }
@@ -246,7 +255,7 @@ public struct AlertToast: View{
                             .renderingMode(.template)
                             .foregroundColor(color)
                     case .loading:
-                        ActivityIndicator()
+                        ActivityIndicator(color: style?.indicatorColor ?? .white)
                     case .regular:
                         EmptyView()
                     }
@@ -292,7 +301,7 @@ public struct AlertToast: View{
                         .hudModifier()
                         .foregroundColor(color)
                 case .loading:
-                    ActivityIndicator()
+                    ActivityIndicator(color: style?.indicatorColor ?? .white)
                 case .regular:
                     EmptyView()
                 }
@@ -359,7 +368,7 @@ public struct AlertToast: View{
                     .padding(.bottom)
                 Spacer()
             case .loading:
-                ActivityIndicator()
+                ActivityIndicator(color: style?.indicatorColor ?? .white)
             case .regular:
                 EmptyView()
             }


### PR DESCRIPTION
When using the following code, you need to change the color of the ActivityIndicator in order to see it
`
AlertToast(displayMode: .alert, type: .loading, style: .style(
    backgroundColor: Color.black
))
`
Now, you can use this:
`
AlertToast(displayMode: .alert, type: .loading, style: .style(
    backgroundColor: Color.black,
    indicatorColor: Color.white
))
`