### PR TITLE
Compatibility to visionOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -7,7 +7,8 @@ let package = Package(
     name: "AlertToast",
     platforms: [
         .iOS(.v14),
-        .macOS(.v11)
+        .macOS(.v11),
+        .visionOS(.v1)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/AlertToast/AlertToast.swift
+++ b/Sources/AlertToast/AlertToast.swift
@@ -436,6 +436,11 @@ public struct AlertToastModifier: ViewModifier{
     private var screen: CGRect {
 #if os(iOS)
         return UIScreen.main.bounds
+#elseif os(visionOS)
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+            return windowScene.coordinateSpace.bounds
+        }
+        return .zero
 #else
         return NSScreen.main?.frame ?? .zero
 #endif


### PR DESCRIPTION
I needed a Toast package for visionOS and managed to make yours work on that platform.

Haven't tested it thoroughly with all options yet, but all display modes worked fine for me.

In order to check the platform, the swift-tools need to be updated to 5.10.

Feel free to merge this PR if you want to.