### PR TITLE
Reolved subtitle cut off issue on iOS banners

### DIFF
--- a/Sources/AlertToast/AlertToast.swift
+++ b/Sources/AlertToast/AlertToast.swift
@@ -266,6 +266,8 @@ public struct AlertToast: View{
                 if let subTitle = subTitle {
                     Text(LocalizedStringKey(subTitle))
                         .font(style?.subTitleFont ?? Font.subheadline)
+                        .lineLimit(nil)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
             .multilineTextAlignment(.leading)


### PR DESCRIPTION
There is an issue with the subtitle which gets cuts of instead of break to new line if `displayMode` is set to `.banner`. These changes resolved that